### PR TITLE
add 1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,4 @@ services: docker
 script: bash ./run.sh
 env:
   - VERSION=0.8.4
+  - VERSION=1.2.0

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 $ make base
 
 # please choose version
-$ docker build --no-cache -t consul-rpm-builder/consul:0.8.4 consul/0.8.4
-$ docker run consul-rpm-builder/consul:0.8.4 > tmp/consul-0.8.4.x86_64.rpm
+$ docker build --no-cache -t consul-rpm-builder/consul:1.2.0 consul/1.2.0
+$ docker run consul-rpm-builder/consul:1.2.0 > tmp/consul-1.2.0.x86_64.rpm
 ```
 
 * Installs no service (use supervisord or else according to your purpose)
@@ -16,7 +16,7 @@ $ docker run consul-rpm-builder/consul:0.8.4 > tmp/consul-0.8.4.x86_64.rpm
 ### Just check files
 
 ```bash
-$ docker run consul-rpm-builder/consul:0.8.4 rpm -qlp /var/tmp/consul.rpm
+$ docker run consul-rpm-builder/consul:1.2.0 rpm -qlp /var/tmp/consul.rpm
 /etc/consul.d
 /etc/consul.json
 /usr/bin/consul
@@ -26,7 +26,7 @@ $ docker run consul-rpm-builder/consul:0.8.4 rpm -qlp /var/tmp/consul.rpm
 ### Just try install
 
 ```bash
-$ docker run consul-rpm-builder/consul:0.8.4 /bin/bash -c 'yum -y install /var/tmp/consul.rpm && consul version'
+$ docker run consul-rpm-builder/consul:1.2.0 /bin/bash -c 'yum -y install /var/tmp/consul.rpm && consul version'
 ```
 
 ### Available components and versions
@@ -43,6 +43,7 @@ $ docker run consul-rpm-builder/consul:0.8.4 /bin/bash -c 'yum -y install /var/t
 - consul:0.8.2
 - consul:0.8.3
 - consul:0.8.4
+- consul:1.2.0
 - consul-web_ui:0.4.1
 - consul-web_ui:0.5.0
 - consul-web_ui:0.6.0

--- a/consul/1.2.0/Dockerfile
+++ b/consul/1.2.0/Dockerfile
@@ -1,0 +1,29 @@
+FROM consul-rpm-builder-base:latest
+
+ENV CONSUL_VERSION 1.2.0
+ENV RPM_EPOCH 1
+
+RUN mkdir -p /rootfs/var/consul/data \
+    /rootfs/etc/consul.d \
+    /rootfs/usr/bin
+ADD default.json /rootfs/etc/consul.json
+ADD postinst.rpm /usr/local/bin/postinst.sh
+
+RUN curl -L https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip > /usr/local/src/consul-${CONSUL_VERSION}_linux_amd64.zip
+RUN unzip -o -u /usr/local/src/consul-${CONSUL_VERSION}_linux_amd64.zip -d /rootfs/usr/bin
+
+RUN fpm -s dir -t rpm -n consul -v ${CONSUL_VERSION} -p /var/tmp/consul.rpm \
+    --rpm-compression bzip2 --rpm-os linux \
+    --force \
+    --iteration $(date +%Y%m%d) \
+    --after-install /usr/local/bin/postinst.sh \
+    --epoch $RPM_EPOCH \
+    --url https://www.consul.io/ \
+    --description "Consul is a tool for service discovery and configuration. Consul is distributed, highly available, and extremely scalable." \
+    --maintainer "Uchio KONDO <udzura@udzura.jp>" \
+    --license "MPLv2.0" \
+    --vendor "hashicorp" -a amd64 \
+    --config-files /etc/consul.json \
+    /rootfs/=/
+
+CMD ["/usr/bin/cat", "/var/tmp/consul.rpm"]

--- a/consul/1.2.0/default.json
+++ b/consul/1.2.0/default.json
@@ -1,0 +1,5 @@
+{
+  "datacenter": "aws-tokyo",
+  "data_dir": "/var/consul/data",
+  "log_level": "INFO"
+}

--- a/consul/1.2.0/postinst.rpm
+++ b/consul/1.2.0/postinst.rpm
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+set -e
+
+if ! id consul; then
+    useradd -d /var/consul consul
+fi
+
+chmod 775 /usr/bin/consul
+chown -R consul:consul /var/consul /etc/consul.d /etc/consul.json
+
+exit 0


### PR DESCRIPTION
build 1.2.0 rpm.

consul-web_ui  is not added so it depricated at 1.2.0.

https://www.consul.io/intro/getting-started/ui.html#how-to-use-the-legacy-ui
> As of Consul version 1.2.0 the original Consul UI is deprecated.